### PR TITLE
Embed comments from comment.create and comment.update into

### DIFF
--- a/Notification/Matrix.php
+++ b/Notification/Matrix.php
@@ -64,6 +64,11 @@ class Matrix extends Base implements NotificationInterface
             $use_colours = true;
         }
 
+        $use_embed_comment = $this->projectMetadataModel->get($project['id'], 'matrix_embed_comments');
+        if (!isset($use_embed_comment)) {
+            $use_embed_comment = true;
+        }
+
         if ($this->userSession->isLogged()) {
             $author = $this->helper->user->getFullname();
             $title = $this->notificationModel->getTitleWithAuthor($author, $event_name, $event_data);
@@ -81,8 +86,43 @@ class Matrix extends Base implements NotificationInterface
             $message .= htmlspecialchars($url);
             $message .= $use_colours ? '</font>' : '';
         }
+        if ($this->hasComments($event_name) && $use_embed_comment) {
+            $message .= '<p>' . $this->extractComment($event_data) . '</p>';
+        }
 
         return $message;
+    }
+    /**
+     * Check whether or not the event has comments and check if the option is enabled
+     * https://docs.kanboard.org/en/latest/developer_guide/webhooks.html?highlight=event_data#list-of-supported-events
+     *
+     * @access private
+     * @param  string    $event_name
+     *
+     */
+
+    private function hasComments($event_name)
+    {
+        switch($event_name) {
+            case "comment.create":
+            case "comment.update";
+                return true;
+            default:
+                return false;
+        }
+    }
+    /**
+     * 
+     * https://docs.kanboard.org/en/latest/developer_guide/webhooks.html?highlight=event_data#examples-of-event-payloads
+     *
+     * @access private
+     * @param  string    $event_data
+     *
+     */
+
+    private function extractComment(array $event_data)
+    {
+        return htmlspecialchars($event_data['comment']['comment']);
     }
 
     /**

--- a/Template/project/integration.php
+++ b/Template/project/integration.php
@@ -10,6 +10,12 @@
     <?= $this->form->checkbox('matrix_send_notices', t('Send messages as notices'), 1, !isset($values['matrix_send_notices']) || $values['matrix_send_notices'] == 1) ?>
     <p class="form-help"><?= t('If switched off, updates will be posted as regular messages') ?></p>
 
+    <?= $this->form->hidden('matrix_embed_comments', array('matrix_embed_comments' => 0)) ?>
+    <?= $this->form->checkbox('matrix_embed_comments', t('Embed comments into messages'), 1, !isset($values['matrix_embed_comments']) || $values['matrix_embed_comments'] == 1) ?>
+    <p class="form-help"><?= t('If switched on, notifications will embed ') ?>
+    <a href="https://docs.kanboard.org/en/latest/developer_guide/webhooks.html?highlight=event_data#examples-of-event-payloads" target="_blank">
+    <?= t('comment.create and comment.update events') ?></a></p>
+
     <p class="form-help"><a href="https://kanboard.net/plugin/matrix" target="_blank"><?= t('Help on Matrix integration') ?></a></p>
 
     <div class="form-actions">


### PR DESCRIPTION
the message

Added per project matrix_embed_comments flag

https://docs.kanboard.org/en/latest/developer_guide/webhooks.html?highlight=event_data#list-of-supported-events



<img width="1087" alt="Screen Shot 2020-07-30 at 10 10 08 PM" src="https://user-images.githubusercontent.com/771339/89002242-7445d780-d2b1-11ea-8f73-45d9eeba4525.png">
